### PR TITLE
Add locking around dictionary as computed property

### DIFF
--- a/Sources/SwiftKafka/NSLock+Extensions.swift
+++ b/Sources/SwiftKafka/NSLock+Extensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+}


### PR DESCRIPTION
`KafkaProducer.kafkaHandleToMessageCallback` is a dictionary that is accessed by multiple threads.  The code in KafkaProducer used a semaphore to prevent concurrent access, but this was missed in accesses outside of that class (such as in `KafkaConfig.setDeliveredMessageCallback()`).

This replaces the semaphore with a computed property and NSLock approach similar to https://github.com/IBM-Swift/LoggerAPI/pull/47 .