### PR TITLE
ci: Add build script for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
-# Travis CI build file for Kitura.
-# Kitura runs on OS X and Linux (Ubuntu).
-# See the following URLs for further details on Travis CI
-# https://docs.travis-ci.com/user/customizing-the-build/
-# https://docs.travis-ci.com/user/docker/
-# https://docs.travis-ci.com/user/multi-os/
+# Travis CI build file.
 
 # whitelist (branches that should be built)
 branches:
@@ -17,26 +12,30 @@ branches:
 matrix:
   include:
     - os: linux
-      dist: trusty
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.1.3
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04
+      env:  DOCKER_IMAGE=swift:4.0.3 SWIFT_SNAPSHOT=4.0.3
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:18.04
+      env: DOCKER_IMAGE=swift:4.1.3 SWIFT_SNAPSHOT=4.1.3
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=swift:4.2.4 SWIFT_SNAPSHOT=4.2.4
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=swift:5.0.1-xenial
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=swift:5.0.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -46,11 +45,20 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.1
       sudo: required
+      env: SWIFT_SNAPSHOT=4.2.1
+    - os: osx
+      osx_image: xcode10.2
+      sudo: required
+    - os: osx
+      osx_image: xcode10.2
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:
+- ./setupKafka.sh
 - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/setupKafka.sh
+++ b/setupKafka.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o verbose
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew update > /dev/null
+    brew cask install java
+    brew install kafka
+    zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties
+    kafka-server-start /usr/local/etc/kafka/server.properties
+    sleep 10
+else
+    apt-get install -y wget
+    wget http://mirror.ox.ac.uk/sites/rsync.apache.org/kafka/2.2.0/kafka_2.12-2.2.0.tgz
+    tar -xzf kafka_2.12-2.2.0.tgz
+    cd kafka_2.12-2.2.0
+    bin/zookeeper-server-start.sh config/zookeeper.properties
+    bin/kafka-server-start.sh config/server.properties
+fi


### PR DESCRIPTION
This pull request changed the .travis file to the standard Kitura one.
We also add the terminal commands to start a Zookeeper and Kafka service which is required for the tests.